### PR TITLE
Remove use of anaconda channels

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: DragDrop_transfer
 channels:
-  - defaults
   - conda-forge
   - bioconda
 dependencies:


### PR DESCRIPTION
As per EMBL's new rules, EMBL-EBI cannot use Anaconda repos. Removed all references to defaults or anaconda channels.

https://www.embl.org/internal-information/updates/access-prevented-to-anaconda/